### PR TITLE
Fix trust walker for init-dataset pod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+certs/
 venv/
 vm-testing/inventory
 vm-testing/vars.yml

--- a/roles/tpa_single_node/tasks/dataset/init.yml
+++ b/roles/tpa_single_node/tasks/dataset/init.yml
@@ -7,3 +7,5 @@
       systemd_file: init-dataset
       network: "{{ tpa_single_node_podman_network }}"
       kube_file_content: "{{ lookup('ansible.builtin.template', 'manifests/init/dataset/Deployment.yaml.j2') | from_yaml }}"
+      configmaps:
+        - "{{ tpa_single_node_kube_manifest_dir }}/ConfigMaps/custom-trust-anchor.yaml"

--- a/roles/tpa_single_node/tasks/infra/oidc.yml
+++ b/roles/tpa_single_node/tasks/infra/oidc.yml
@@ -26,7 +26,6 @@
     mode: "0600"
 
 - name: Apply storage secret manifest
-
   ansible.builtin.command:
     cmd: "podman kube play {{ tpa_single_node_oidc_secret }}"
   changed_when: true

--- a/roles/tpa_single_node/templates/manifests/bombastic/api/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/bombastic/api/Deployment.yaml.j2
@@ -38,7 +38,7 @@ spec:
         - name: trust-anchor
           configMap:
             name: custom-trust-anchor
-        - name: bombastic-api-oidc-secret
+        - name: oidc-secret
           secret:
             secretName: oidc_secret
       containers:
@@ -124,8 +124,8 @@ spec:
             - name: trust-anchor
               mountPath: /etc/trust-anchor
               readOnly: true
-            - name: bombastic-api-oidc-secret
-              mountPath: /etc/bombasticapioidc
+            - name: oidc-secret
+              mountPath: /etc/oidc-secret
             - name: config-auth
               mountPath: /etc/config/auth.yaml
               subPath: auth.yaml

--- a/roles/tpa_single_node/templates/manifests/bombastic/walker/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/bombastic/walker/Deployment.yaml.j2
@@ -46,7 +46,7 @@ spec:
             - /walker-state/since
           env:
             - name: RUST_LOG
-              value: ${LOG_LEVEL}
+              value: "info"
             - name: INFRASTRUCTURE_ENABLED
               value: "true"
             - name: INFRASTRUCTURE_BIND

--- a/roles/tpa_single_node/templates/manifests/collector/osv/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/collector/osv/Deployment.yaml.j2
@@ -35,7 +35,7 @@ spec:
         - name: config-auth
           configMap:
             name: collector-osv-auth
-        - name: collector-oidc-secret
+        - name: oidc-secret
           secret:
             secretName: oidc_secret
         - name: trust-anchor
@@ -104,8 +104,8 @@ spec:
             - mountPath: /etc/tls
               name: tls
               readOnly: true
-            - mountPath: /etc/colloidcsecret
-              name: collector-oidc-secret
+            - mountPath: /etc/oidc-secret
+              name: oidc-secret
             - name: config-auth
               mountPath: /etc/config/auth.yaml
               subPath: auth.yaml

--- a/roles/tpa_single_node/templates/manifests/guac/graphql/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/guac/graphql/Deployment.yaml.j2
@@ -34,7 +34,6 @@ spec:
             - --db-address=postgres://{{ tpa_single_node_pg_user }}:{{ tpa_single_node_pg_user_passwd }}@{{ tpa_single_node_pg_host }}:{{ tpa_single_node_pg_port }}/{{ tpa_single_node_pg_db }}?sslmode={{ tpa_single_node_pg_ssl_mode }}
             - --db-driver=postgres
             - --db-debug=true
-          workingDir: /opt/guac
           volumeMounts: null
       containers:
         - name: service
@@ -46,19 +45,34 @@ spec:
             - --gql-backend=ent
             - --db-address=postgres://{{ tpa_single_node_pg_user }}:{{ tpa_single_node_pg_user_passwd }}@{{ tpa_single_node_pg_host }}:{{ tpa_single_node_pg_port }}/{{ tpa_single_node_pg_db }}?sslmode={{ tpa_single_node_pg_ssl_mode }}
             - --db-driver=postgres
-          workingDir: /opt/guac
+            - --db-migrate=false
+            - --db-debug=true
+          workingDir: "/opt/guac"
           env:
+            - name: GUAC_GQL_TLS_CERT_FILE
+              value: /etc/tls/tls.crt
+            - name: GUAC_GQL_TLS_KEY_FILE
+              value: /etc/tls/tls.key
             - name: GUAC_PROMETHEUS_ADDR
-              value: '9010'
+              value: "9010"
           volumeMounts:
+            - mountPath: /etc/tls
+              name: tls
+              readOnly: true
             - name: trust-anchor
               mountPath: /etc/trust-anchor
               readOnly: true
           readinessProbe:
             httpGet:
               path: /healthz
-              port: {{ tpa_single_node_guac_graphql_port }}
-              scheme: HTTP
+              port: 9010
+              scheme: HTTPS
+          livenessProbe:
+            initialDelaySeconds: 2
+            httpGet:
+              path: /healthz
+              port: 9010
+              scheme: HTTPS
           ports:
             - containerPort: 9010
               protocol: TCP
@@ -66,6 +80,8 @@ spec:
             - containerPort: {{ tpa_single_node_guac_graphql_port }}
               protocol: TCP
               name: endpoint
+              hostPort: {{ tpa_single_node_guac_graphql_port }}
+              hostIP: {{ tpa_single_node_rhel_host }}
       volumes:
         - name: tls
           secret:
@@ -73,3 +89,4 @@ spec:
         - name: trust-anchor
           configMap:
             name: custom-trust-anchor
+

--- a/roles/tpa_single_node/templates/manifests/guac/graphql/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/guac/graphql/Deployment.yaml.j2
@@ -42,11 +42,13 @@ spec:
           command:
             - /opt/guac/guacgql 
           args:
-            - --gql-backend=ent
+            - --gql-listen-port={{ tpa_single_node_guac_graphql_port }}
+            - --gql-backend=ent 
             - --db-address=postgres://{{ tpa_single_node_pg_user }}:{{ tpa_single_node_pg_user_passwd }}@{{ tpa_single_node_pg_host }}:{{ tpa_single_node_pg_port }}/{{ tpa_single_node_pg_db }}?sslmode={{ tpa_single_node_pg_ssl_mode }}
             - --db-driver=postgres
             - --db-migrate=false
             - --db-debug=true
+            - --gql-debug=true
           workingDir: "/opt/guac"
           env:
             - name: GUAC_GQL_TLS_CERT_FILE
@@ -89,4 +91,3 @@ spec:
         - name: trust-anchor
           configMap:
             name: custom-trust-anchor
-

--- a/roles/tpa_single_node/templates/manifests/guac/vexination-collector/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/guac/vexination-collector/Deployment.yaml.j2
@@ -104,8 +104,8 @@ spec:
           volumeMounts:
             - name: vex-collector-storage-secret
               mountPath: /etc/vexcolstoragesecret
-            - name: vex-collector-oidc-secret
-              mountPath: /etc/vexcoloidcsecret
+            - name: oidc-secret
+              mountPath: /etc/oidc-secret
             - name: trust-anchor
               mountPath: /etc/trust-anchor
               readOnly: true
@@ -113,7 +113,7 @@ spec:
         - name: vex-collector-storage-secret
           secret:
             secretName: storage_secret
-        - name: vex-collector-oidc-secret
+        - name: oidc-secret
           secret:
             secretName: oidc_secret
         - name: trust-anchor

--- a/roles/tpa_single_node/templates/manifests/init/dataset/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/init/dataset/Deployment.yaml.j2
@@ -15,11 +15,18 @@ spec:
         app: init-dataset
     spec:
       restartPolicy: OnFailure
+      volumes:
+        - name: oidc-secret
+          secret:
+            secretName: oidc_secret
+        - name: trust-anchor
+          configMap:
+            name: custom-trust-anchor
       containers:
         - name: run
           image: "{{ tpa_single_node_trustification_image }}"
           imagePullPolicy: IfNotPresent
-          command: [ "/usr/bin/bash" ]
+          command: [ "/bin/bash" ]
           args:
             - "-ce"
             - |
@@ -38,3 +45,9 @@ spec:
               value: "{{ tpa_single_node_oidc_issuer_url }}"
             - name: RUST_LOG
               value: "info"
+          volumeMounts:
+            - mountPath: /etc/oidc-secret
+              name: oidc-secret
+            - name: trust-anchor
+              mountPath: /etc/trust-anchor
+              readOnly: true

--- a/roles/tpa_single_node/templates/manifests/init/dataset/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/init/dataset/Deployment.yaml.j2
@@ -31,8 +31,8 @@ spec:
             - "-ce"
             - |
               set -e
-              /trust bombastic walker --sink https://{{ tpa_single_node_rhel_host }}:{{ tpa_single_node_bombastic_api_port }} --source file:/data/sbom
-              /trust vexination walker --sink https://{{ tpa_single_node_rhel_host }}:{{ tpa_single_node_vexination_api_port }}/api/v1/vex --source file:/data/csaf
+              /trust bombastic walker --sink https://{{ tpa_single_node_rhel_host }}:{{ tpa_single_node_bombastic_api_port }} --source file:/data/sbom --sender-root-certificates /etc/trust-anchor/tls.crt
+              /trust vexination walker --sink https://{{ tpa_single_node_rhel_host }}:{{ tpa_single_node_vexination_api_port }}/api/v1/vex --source file:/data/csaf --sender-root-certificates /etc/trust-anchor/tls.crt
           env:
             - name: OIDC_PROVIDER_CLIENT_ID
               value: "{{ tpa_single_node_oidc_provider_client_id }}"

--- a/roles/tpa_single_node/templates/manifests/spog/api/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/spog/api/Deployment.yaml.j2
@@ -107,8 +107,8 @@ spec:
             - name: trust-anchor
               mountPath: /etc/trust-anchor
               readOnly: true
-            - mountPath: /etc/spogapioidcsecret
-              name: spog-api-oidc-secret
+            - mountPath: /etc/oidc-secret
+              name: oidc-secret
           livenessProbe:
             initialDelaySeconds: 2
             httpGet:
@@ -132,6 +132,6 @@ spec:
         - name: trust-anchor
           configMap:
             name: custom-trust-anchor
-        - name: spog-api-oidc-secret
+        - name: oidc-secret
           secret:
             secretName: oidc_secret

--- a/roles/tpa_single_node/templates/manifests/spog/api/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/spog/api/Deployment.yaml.j2
@@ -49,7 +49,7 @@ spec:
             - --crda-url
             - https://rhda.rhcloud.com/api/v4/analysis
             - --guac
-            - http://guac-graphql-pod:{{ tpa_single_node_guac_graphql_port }}/query
+            - https://{{ tpa_single_node_rhel_host }}:{{ tpa_single_node_guac_graphql_port }}/query
             - --auth-configuration
             - /etc/config/auth.yaml
           env:

--- a/roles/tpa_single_node/templates/manifests/v11y/api/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/v11y/api/Deployment.yaml.j2
@@ -34,7 +34,7 @@ spec:
         - name: v11y-api-storage-secret
           secret:
             secretName: storage_secret
-        - name: v11y-api-oidc-secret
+        - name: oidc-secret
           secret:
             secretName: oidc_secret
         - name: tls
@@ -75,8 +75,8 @@ spec:
               subPath: auth.yaml
             - mountPath: /etc/v11yapistoragesecret
               name: v11y-api-storage-secret
-            - mountPath: /etc/v11yapioidcsecret
-              name: v11y-api-oidc-secret
+            - mountPath: /etc/oidc-secret
+              name: oidc-secret
             - name: trust-anchor
               mountPath: /etc/trust-anchor
               readOnly: true

--- a/roles/tpa_single_node/templates/manifests/vexination/api/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/vexination/api/Deployment.yaml.j2
@@ -40,7 +40,7 @@ spec:
         - name: trust-anchor
           configMap:
             name: custom-trust-anchor
-        - name: vexination-api-oidc-secret
+        - name: oidc-secret
           secret:
             secretName: oidc_secret
       containers:
@@ -78,8 +78,8 @@ spec:
             - name: trust-anchor
               mountPath: /etc/trust-anchor
               readOnly: true
-            - mountPath: /etc/vexapioidcsecret
-              name: vexination-api-oidc-secret
+            - mountPath: /etc/oidc-secret
+              name: oidc-secret
           livenessProbe:
             initialDelaySeconds: 2
             httpGet:

--- a/roles/tpa_single_node/templates/manifests/vexination/walker/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/vexination/walker/Deployment.yaml.j2
@@ -17,7 +17,7 @@ spec:
         - name: walker-state
           persistentVolumeClaim:
             claimName: vexination-walker-state
-        - name: vexination-walker-oidc-secret
+        - name: oidc-secret
           secret:
             secretName: oidc_secret
         - name: trust-anchor
@@ -63,8 +63,8 @@ spec:
           volumeMounts:
             - mountPath: /walker-state
               name: walker-state
-            - mountPath: /etc/vexwalkeroidcsecret
-              name: vexination-walker-oidc-secret
+            - mountPath: /etc/oidc-secret
+              name: oidc-secret
             - name: trust-anchor
               mountPath: /etc/trust-anchor
               readOnly: true              

--- a/roles/tpa_single_node/vars/main.yml
+++ b/roles/tpa_single_node/vars/main.yml
@@ -2,7 +2,7 @@
 # vars file for tpa_scaffolding
 tpa_single_node_base_hostname: trustification
 tpa_single_node_rhel_host: "{{ lookup('env', 'TPA_RHEL_HOST') | default('192.168.121.60', true) }}"
-tpa_single_node_certificates_dir: /tmp/rhtpa/certs/
+tpa_single_node_certificates_dir: ./certs/
 tpa_single_node_config_dir: /etc/rhtpa
 tpa_single_node_kube_manifest_dir: "{{ tpa_single_node_config_dir }}/manifests"
 tpa_single_node_namespace: trustification


### PR DESCRIPTION
- Fix init-dataset : 
  - address missing OIDC_PROVIDER_CLIENT_SECRET
  - pass root CA as parameter
- Simplify oidc-secret names accross deployment manifests
- Restore TLS for guac-graphql and open port on host to help debug (for ongoing investigations)
- gencerts use local directory `./certs`

![image](https://github.com/user-attachments/assets/9e2dfcf3-9c8c-4846-9b5f-454eeab883e1)

