### PR TITLE
No log for podman login

### DIFF
--- a/roles/tpa_single_node/tasks/podman.yml
+++ b/roles/tpa_single_node/tasks/podman.yml
@@ -11,6 +11,12 @@
   ansible.builtin.command: podman login registry.redhat.io -u {{ tpa_single_node_registry_username }} -p {{ tpa_single_node_registry_password }}
   register: podman_login_result
   changed_when: '"Already logged in" not in podman_login_result'
+  no_log: true
+
+- name: Check if Podman login succeeded
+  ansible.builtin.fail:
+    msg: "Podman login failed!"
+  when: podman_login_result.rc != 0
 
 - name: Create Manifests/Configs Directory
   ansible.builtin.file:


### PR DESCRIPTION
Added no_log to podman login step - which would returns code '0' if the login failed.
Screenshots with test
Successful login:
![Screenshot from 2024-10-23 19-09-13](https://github.com/user-attachments/assets/fcbf91ac-8a91-4b56-9757-eab8e89afc8c)
Failed login:
![Screenshot from 2024-10-23 19-08-50](https://github.com/user-attachments/assets/b2bdd371-adc7-42cb-9aa6-94f8c750fa8b)
