### PR TITLE
Resolve conflicting `required` and `default` stanza

### DIFF
--- a/roles/tpa_single_node/meta/argument_specs.yml
+++ b/roles/tpa_single_node/meta/argument_specs.yml
@@ -80,25 +80,21 @@ argument_specs:
         type: "str"
         required: true
         version_added: "1.2.0"
-        default: "postgres"
       tpa_single_node_pg_admin_passwd:
         description: "DB admin password."
         type: "str"
         required: true
         version_added: "1.2.0"
-        default: "posgres1234"
       tpa_single_node_pg_user:
         description: "DB user."
         type: "str"
         required: true
         version_added: "0.2.0"
-        default: "guac"
       tpa_single_node_pg_user_passwd:
         description: "DB user password."
         type: "str"
         required: true
         version_added: "0.2.0"
-        default: "guac1234"
       tpa_single_node_pg_ssl_mode:
         description: "DB SSL mode require/disabled."
         type: "str"


### PR DESCRIPTION
Resolve current bug:

```sh
fatal: [192.168.121.60]: FAILED! => {"argument_errors": ["internal error: required and default are mutually exclusive for tpa_single_node_pg_admin"]
```