### PR TITLE
[TC-1947] Replacing the tcp check on the liveness probe because it needs nc installed

### DIFF
--- a/roles/tpa_single_node/templates/manifests/guac/collectsub/Deployment.yaml.j2
+++ b/roles/tpa_single_node/templates/manifests/guac/collectsub/Deployment.yaml.j2
@@ -46,8 +46,11 @@ spec:
               name: tls-cert
               readOnly: true
           livenessProbe:
-            tcpSocket:
-              port: 2782
+            exec:
+              command:
+                - sh
+                - -c
+                - "echo > /dev/tcp/localhost/2782"
           ports:
             - containerPort: 2782
               protocol: TCP


### PR DESCRIPTION
Podman kube play use nc for the tcpProbes
https://github.com/containers/podman/blob/v4.5.0/pkg/specgen/generate/kube/kube.go#L596

and is not provided by the ubi image

https://issues.redhat.com/browse/TC-1947